### PR TITLE
Allow accessing ports by name

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 var (
 	cfg = config.MustNew("midicat", VERSION, "midicat transfers MIDI data between midi ports and stdin/stdout")
 
-	argPortNum  = cfg.NewInt32("index", "index of the midi port. Only specify either the index or the name. If neither is given, the first port is used.", config.Shortflag('i'))
+	argPortNum  = cfg.NewInt32("index", "index of the midi port. Only specify either the index or the name. If neither is given, the first port is used.", config.Shortflag('i'), config.Default(int32(-1)))
 	argPortName = cfg.NewString("name", "name of the midi port. Only specify either the index or the name. If neither is given, the first port is used.")
 	argJson     = cfg.NewBool("json", "return the list in JSON format")
 


### PR DESCRIPTION
This defaults the value of --index to -1, which allows the --name
option to work as intending. The underlying midi library only uses the
name in `midi.OpenIn` and `midi.OpenOut` if the port number is < 0.

Closes #1
